### PR TITLE
Use "set par()" instead of "show par: set block()"

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -83,7 +83,7 @@ long } }
   // Default leading is 0.65em.
   set par(leading: 0.7em, justify: true, linebreaks: "optimized")
   // Default spacing is 1.2em.
-  show par: set block(spacing: 1.35em)
+  set par(spacing: 1.35em)
 
   show heading: it => {
     v(2.5em, weak: true)


### PR DESCRIPTION
`show par: set block(spacing: ..)` has no effect anymore, as paragraphs are not considered blocks anymore.

Use `set par(spacing: ..)` instead.

