### PR TITLE
Migrate outline fill to Typst 0.13

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -174,7 +174,8 @@ long } }
   }
 
   // Indent nested entries in the outline.
-  set outline(indent: auto, fill: repeat([#h(2.5pt) . #h(2.5pt)]))
+  set outline(indent: auto)
+  set outline.entry(fill: repeat([#h(2.5pt) . #h(2.5pt)]))
 
   show outline.entry: it => {
     // Only apply styling if we're in the table of contents (not list of figures or list of tables, etc.)


### PR DESCRIPTION
`fill` argument is now at the [outline.entry](https://typst.app/docs/reference/model/outline/#definitions-entry) level

To fix #3, according to https://typst.app/blog/2025/typst-0.13/#outline-migration

I'm not entirely sure, please check.